### PR TITLE
(perf)UI: Render performance

### DIFF
--- a/src/iOS/HealthSense/HealthSense/Controller/Skeleton/ViewController.swift
+++ b/src/iOS/HealthSense/HealthSense/Controller/Skeleton/ViewController.swift
@@ -12,29 +12,49 @@ class ViewController: UIViewController {
 
     let healthKitManager = HealthKitManager.sharedInstance
     
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        print("Main viewDidLoad ViewController")
-
+        print("#### Main viewDidLoad ViewController")
+        if UserDefaults.standard.bool(forKey: HSUserDefaults.kFirstLaunch.rawValue) {
+            print("Default launch")
+            Settings.sharedInstance.appRestoreSettings()
+        } else {
+            print("First launch")
+            Settings.sharedInstance.setAppSettings()
+        }
+        
+        Analytics().setup()
 //        commented function for programmatic UI
 //        programmaticUI()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        print("###### viewWillAppear")
+    }
     
     override func viewDidAppear(_ animated: Bool) {
+        print("###### View Did Appear")
+        /* This code flow works if we utilize SceneDelegate
+         window?.rootViewController = ViewController()
+         -> Loads this class which then loads the respective storyboard "Summary" or "Onboarding"
+         By moving our dynamic UI logic in Scene Delegate we removed the blackscreen on launch and
+         also calculated which UI to be displayed at the right place.
+         */
         // Dynamic UI Screen Presenter
         if SettingsStruct.defaultScreen == HSRouter.kSummary.rawValue {
             print("Default screen flow")
-            let onboardStoryboard = UIStoryboard(name: "Main", bundle: nil)
-            let viewC = onboardStoryboard.instantiateViewController(identifier: "UITabBarViewController")
+            let onboardStoryboard = UIStoryboard(name: HSStoryboard.kHomeVC.rawValue, bundle: nil)
+            let viewC = onboardStoryboard.instantiateViewController(identifier: HSCustomViewController.kTabBarVC.rawValue)
             viewC.modalPresentationStyle = .fullScreen
             self.present(viewC, animated: false)
-            
-        } else if SettingsStruct.defaultScreen == "welcome" {
+
+        } else if SettingsStruct.defaultScreen == HSRouter.kWelcome.rawValue {
             print("Welcome screen flow")
-            let onboardStoryboard = UIStoryboard(name: "Onboarding", bundle: nil)
-            let viewC = onboardStoryboard.instantiateViewController(identifier: "OnboardingViewController")
+            let onboardStoryboard = UIStoryboard(name: HSStoryboard.kOnboardingVC.rawValue, bundle: nil)
+            let viewC = onboardStoryboard.instantiateViewController(identifier: HSCustomViewController.kOnboardingVC.rawValue)
             viewC.modalPresentationStyle = .fullScreen
             self.present(viewC, animated: true)
         }
@@ -59,7 +79,7 @@ class ViewController: UIViewController {
     
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "onboarding" {
+        if segue.identifier == HSStoryboardSegue.kOnboardingViewS.rawValue {
             
             /* Manually presenting the View controller segue with fullscreen. But it throws stack error saying Storyboard can't find FirstOnboardingVC & also Console log warning message.
             let storyboard = UIStoryboard(name: "Onboarding", bundle: nil)

--- a/src/iOS/HealthSense/HealthSense/Info.plist
+++ b/src/iOS/HealthSense/HealthSense/Info.plist
@@ -37,16 +37,12 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
@@ -54,8 +50,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/src/iOS/HealthSense/HealthSense/Main/AppDelegate.swift
+++ b/src/iOS/HealthSense/HealthSense/Main/AppDelegate.swift
@@ -16,19 +16,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Override point for customization after application launch.
         print("#### App Delegate")
-        
-        if UserDefaults.standard.bool(forKey: "FirstLaunch") {
-            print("Default launch")
-            Settings.sharedInstance.appRestoreSettings()
-        } else {
-            print("First launch")
-            Settings.sharedInstance.setAppSettings()
-        }
-        
-        // Calling Analytics class
-        // TODO: Could be moved to lazy class invokation after the initial loading of Screens are done.
-        Analytics().setup()
-        
         return true
     }
 

--- a/src/iOS/HealthSense/HealthSense/Main/SceneDelegate.swift
+++ b/src/iOS/HealthSense/HealthSense/Main/SceneDelegate.swift
@@ -22,10 +22,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Setting default Window View Controller programmatically. We can also remove "Main" storyboard references in Main proj and info.plist
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = ViewController()
+        
+        if UserDefaults.standard.bool(forKey: HSUserDefaults.kFirstLaunch.rawValue) {
+            print("Default launch")
+            Settings.sharedInstance.appRestoreSettings()
+            let storyboard = UIStoryboard(name: HSStoryboard.kHomeVC.rawValue, bundle: nil)
+            self.window?.rootViewController = storyboard.instantiateViewController(identifier: HSCustomViewController.kTabBarVC.rawValue)
+        } else {
+            print("First launch")
+            Settings.sharedInstance.setAppSettings()
+            let storyboard = UIStoryboard(name: HSStoryboard.kOnboardingVC.rawValue, bundle: nil)
+            self.window?.rootViewController = storyboard.instantiateViewController(identifier: HSCustomViewController.kOnboardingVC.rawValue)
+        }
+        Analytics().setup()
+        // Old way of checking for those Structs and letting ViewController handle the UX logic
+//        window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
-        //TODO: Maybe we can dynamically assign views control flow in SceneDelegate itself.
-       // 1 sec Black screen compared to Viewcontroller function viewDidLoad() and then viewDidAppear(), so there are already 4 extra overhead calls
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/src/iOS/HealthSense/HealthSense/Storyboard/Base.lproj/Main.storyboard
+++ b/src/iOS/HealthSense/HealthSense/Storyboard/Base.lproj/Main.storyboard
@@ -64,7 +64,7 @@
         <!--Summary-->
         <scene sceneID="lbv-9x-rSy">
             <objects>
-                <viewControllerPlaceholder storyboardName="Summary" id="nWa-Qd-rYG" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardIdentifier="SummaryVC" storyboardName="Summary" id="nWa-Qd-rYG" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Summary" image="anonymous" id="Ifv-c5-LPe"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cMi-6G-zWq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/src/iOS/HealthSense/HealthSense/Storyboard/Screens/Summary.storyboard
+++ b/src/iOS/HealthSense/HealthSense/Storyboard/Screens/Summary.storyboard
@@ -10,7 +10,7 @@
         <!--Summary-->
         <scene sceneID="QH7-Uy-g4l">
             <objects>
-                <viewController id="JL4-bz-0PJ" customClass="SummaryViewController" customModule="HealthSense" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SummaryViewController" id="JL4-bz-0PJ" customClass="SummaryViewController" customModule="HealthSense" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lz0-Zz-cy5">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
Changelog:

- Dynamic UI screen allotment.
- Removed "Main" storyboard links from Info Plist
- Moved code from App delegate / View controller -> Scene delegate
- Storyboard Identifier assigned.
- Also Portrait Only support right now.
- Added comments regarding this big change of code flow at every app launch.
- Moved Analytics initializer in new function so no return object callback. (Silenced the Xcode empty returned object warning)

 **Please check if the PR fulfills these requirements**

 Code Style

- [x] The commit message follows our guidelines
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] Fixed merge conflicts with Master branch as base.

 Documentation

- [ ] My change requires a change to the documentation.
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] I have updated the documentation accordingly.

 Tests

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Tests for the changes have been added (for bug fixes / features)

 **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

 **Relevant Issues**

Fixes #53 

 **What is the current behavior?** (You can also link to an open issue here)

 **What is the new behavior (if this is a feature change)?**

 **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- [ ] Github Actions
- [ ] Travis CI

 **Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [ ] Tested on Desktop
- [x] Tested on iPhone
- [ ] Tested on Android
- [ ] Tested on Apple Watch
- [x] Tested on Xcode Simulator
- [ ] Tested on Simulator

 **Screenshots**

 **Other information**:
